### PR TITLE
Add support for disabling AUTOBND on Telit modems

### DIFF
--- a/plugins/telit/mm-broadband-modem-le910c4-telit.c
+++ b/plugins/telit/mm-broadband-modem-le910c4-telit.c
@@ -22,6 +22,7 @@
 #include "mm-base-modem-at.h"
 #include "mm-modem-helpers-telit.h"
 #include "mm-shared-qmi.h"
+#include "mm-shared-telit.h"
 
 /* index to use with AT#FWSWITCH to select firmware */
 #define NON_VERIZON_FIRMWARE_INDEX 0
@@ -77,10 +78,20 @@ mm_firmware_change_register_task_telit_start (MMIfaceModem3gpp    *self,
                                               GAsyncReadyCallback callback,
                                               gpointer            user_data);
 
+static void
+set_current_bands (MMIfaceModem        *self,
+                   GArray              *bands_array,
+                   GAsyncReadyCallback  callback,
+                   gpointer             user_data);
+
+static void iface_modem_init (MMIfaceModem *iface);
 static void iface_modem_3gpp_init (MMIfaceModem3gpp *iface);
+static void shared_telit_init (MMSharedTelit *iface);
 
 G_DEFINE_TYPE_EXTENDED (MMBroadbandModemLe910c4Telit, mm_broadband_modem_le910c4_telit, MM_TYPE_BROADBAND_MODEM_QMI, 0,
-                        G_IMPLEMENT_INTERFACE (MM_TYPE_IFACE_MODEM_3GPP, iface_modem_3gpp_init));
+                        G_IMPLEMENT_INTERFACE (MM_TYPE_IFACE_MODEM, iface_modem_init)
+                        G_IMPLEMENT_INTERFACE (MM_TYPE_IFACE_MODEM_3GPP, iface_modem_3gpp_init)
+                        G_IMPLEMENT_INTERFACE (MM_TYPE_SHARED_TELIT, shared_telit_init));
 
 /*****************************************************************************/
 
@@ -106,9 +117,20 @@ mm_broadband_modem_le910c4_telit_init (MMBroadbandModemLe910c4Telit *self)
 }
 
 static void
+iface_modem_init (MMIfaceModem *iface)
+{
+    iface->set_current_bands = set_current_bands;
+}
+
+static void
 iface_modem_3gpp_init (MMIfaceModem3gpp *iface)
 {
     iface->register_in_network = mm_firmware_change_register_task_telit_start;
+}
+
+static void
+shared_telit_init (MMSharedTelit *iface)
+{
 }
 
 static void
@@ -408,4 +430,18 @@ mm_firmware_change_register_task_telit_start (MMIfaceModem3gpp    *self,
     task = g_task_new (self, NULL, firmware_steps_done, ctx);
     g_task_set_task_data (task, ctx, (GDestroyNotify) firmware_change_register_context_free);
     firmware_change_register_step (task);
+}
+
+static void
+set_current_bands (MMIfaceModem        *self,
+                   GArray              *bands_array,
+                   GAsyncReadyCallback  callback,
+                   gpointer             user_data)
+{
+    /* Disable Telit AUTOBND when setting bands manually */
+    mm_shared_telit_modem_disable_autoband (self,
+                                            bands_array,
+                                            callback,
+                                            mm_shared_qmi_set_current_bands,
+                                            user_data);
 }

--- a/plugins/telit/mm-broadband-modem-mbim-telit.c
+++ b/plugins/telit/mm-broadband-modem-mbim-telit.c
@@ -128,6 +128,20 @@ load_supported_modes (MMIfaceModem *self,
                               task);
 }
 
+static void
+set_current_bands (MMIfaceModem        *self,
+                   GArray              *bands_array,
+                   GAsyncReadyCallback  callback,
+                   gpointer             user_data)
+{
+    /* Disable Telit AUTOBND when setting bands manually */
+    mm_shared_telit_modem_disable_autoband (self,
+                                            bands_array,
+                                            callback,
+                                            mm_shared_telit_modem_set_current_bands,
+                                            user_data);
+}
+
 /*****************************************************************************/
 
 MMBroadbandModemMbimTelit *
@@ -156,7 +170,7 @@ mm_broadband_modem_mbim_telit_init (MMBroadbandModemMbimTelit *self)
 static void
 iface_modem_init (MMIfaceModem *iface)
 {
-    iface->set_current_bands = mm_shared_telit_modem_set_current_bands;
+    iface->set_current_bands = set_current_bands;
     iface->set_current_bands_finish = mm_shared_telit_modem_set_current_bands_finish;
     iface->load_current_bands = mm_shared_telit_modem_load_current_bands;
     iface->load_current_bands_finish = mm_shared_telit_modem_load_bands_finish;

--- a/plugins/telit/mm-broadband-modem-telit.c
+++ b/plugins/telit/mm-broadband-modem-telit.c
@@ -990,6 +990,19 @@ modem_3gpp_enable_unsolicited_events (MMIfaceModem3gpp    *self,
         task);
 }
 
+static void
+set_current_bands (MMIfaceModem        *self,
+                   GArray              *bands_array,
+                   GAsyncReadyCallback  callback,
+                   gpointer             user_data)
+{
+    /* Disable Telit AUTOBND when setting bands manually */
+    mm_shared_telit_modem_disable_autoband (self,
+                                            bands_array,
+                                            callback,
+                                            mm_shared_telit_modem_set_current_bands,
+                                            user_data);
+}
 /*****************************************************************************/
 
 MMBroadbandModemTelit *
@@ -1028,7 +1041,7 @@ iface_modem_init (MMIfaceModem *iface)
 {
     iface_modem_parent = g_type_interface_peek_parent (iface);
 
-    iface->set_current_bands = mm_shared_telit_modem_set_current_bands;
+    iface->set_current_bands = set_current_bands;
     iface->set_current_bands_finish = mm_shared_telit_modem_set_current_bands_finish;
     iface->load_current_bands = mm_shared_telit_modem_load_current_bands;
     iface->load_current_bands_finish = mm_shared_telit_modem_load_bands_finish;

--- a/plugins/telit/mm-shared-telit.h
+++ b/plugins/telit/mm-shared-telit.h
@@ -32,6 +32,10 @@
 #define MM_SHARED_TELIT_GET_INTERFACE(obj)     (G_TYPE_INSTANCE_GET_INTERFACE ((obj), MM_TYPE_SHARED_TELIT, MMSharedTelit))
 
 typedef struct _MMSharedTelit MMSharedTelit;
+typedef void (*MMSharedTelitSetCurrentBands) (MMIfaceModem *self,
+                                              GArray *bands_array,
+                                              GAsyncReadyCallback callback,
+                                              gpointer user_data);
 
 struct _MMSharedTelit {
     GTypeInterface g_iface;
@@ -82,5 +86,11 @@ void        mm_shared_telit_modem_set_current_bands     (MMIfaceModem *self,
                                                          GArray *bands_array,
                                                          GAsyncReadyCallback callback,
                                                          gpointer user_data);
+
+void        mm_shared_telit_modem_disable_autoband       (MMIfaceModem *self,
+                                                          GArray *bands_array,
+                                                          GAsyncReadyCallback callback,
+                                                          MMSharedTelitSetCurrentBands set_current_bands,
+                                                          gpointer user_data);
 
 #endif  /* MM_SHARED_TELIT_H */


### PR DESCRIPTION
This updates set_current_bands for mm_broadband_modem_le910c4 (used by
Telit QMI modems), mm_broadband_modem_mbim_telit, and
mm_broadband_modem_telit to disable AUTOBND when bands are
selected. AUTOBND (automatic band selection) overrides any manually
selected bands when enabled and defeats the purpose of manually
selecting bands (AUTOBND is equivalent to having all bands selected).